### PR TITLE
Make sure Hugging Face download stats work, better discoverability

### DIFF
--- a/add_hf.py
+++ b/add_hf.py
@@ -1,0 +1,18 @@
+from omdet.infernece.det_engine import DetEngine
+from omdet.omdet_v2_turbo.detector import OmDetV2Turbo
+
+
+if __name__ == "__main__":
+    engine = DetEngine(batch_size=1, device='cuda')
+    img_paths = ['./sample_data/000000574769.jpg']       # path of images
+    labels = ["person", "cat", "orange"]          # labels to be predicted
+    prompt = 'Detect {}.'.format(','.join(labels))        # prompt of detection task, use "Detect {}." as default
+
+    model_id = 'OmDet-Turbo_tiny_SWIN_T'
+    model, cfg = engine._load_model(model_id)
+
+    # push to hub
+    model.push_to_hub("nielsr/omde-v2-turbo-tiny-swin-tiny")
+
+    # reload
+    model = OmDetV2Turbo.from_pretrained("nielsr/omde-v2-turbo-tiny-swin-tiny")

--- a/omdet/infernece/det_engine.py
+++ b/omdet/infernece/det_engine.py
@@ -62,6 +62,8 @@ class DetEngine(BaseEngine):
 
         model, cfg = self._load_model(model_id)
 
+        print("Type of model:", type(model))
+
         resp = []
         flat_labels = labels
 

--- a/omdet/infernece/det_engine.py
+++ b/omdet/infernece/det_engine.py
@@ -62,8 +62,6 @@ class DetEngine(BaseEngine):
 
         model, cfg = self._load_model(model_id)
 
-        print("Type of model:", type(model))
-
         resp = []
         flat_labels = labels
 

--- a/omdet/omdet_v2_turbo/detector.py
+++ b/omdet/omdet_v2_turbo/detector.py
@@ -26,9 +26,11 @@ from detectron2.modeling.meta_arch.build import META_ARCH_REGISTRY
 
 from ..utils.cache import LRUCache
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 @META_ARCH_REGISTRY.register()
-class OmDetV2Turbo(nn.Module):
+class OmDetV2Turbo(nn.Module, PyTorchModelHubMixin):
 
     @configurable
     def __init__(self, cfg):


### PR DESCRIPTION
Dear @P3ngLiu and team,

Thanks for this nice work! I see you already pushed the model to the hub which is great: https://huggingface.co/omlab/OmDet-Turbo_tiny_SWIN_T/tree/main, however currently download metrics aren't working for your model + there are no tags in the model card which means it's hard for people to find it.

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the OmDet model using `from_pretrained` (and push it using `push_to_hub`), track download number (similar to models in the Transformers library), and have a nice model card. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from omdet.omdet_v2_turbo.detector import OmDetV2Turbo

model = OmDetV2Turbo.from_pretrained("nielsr/omdet-v2-turbo-tiny-swin-tiny")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads it automatically from the hub. The `safetensors` format is used to ensure safe serialization of the weights rather than pickle.

To improve discoverability, we can add a "zero-shot-object-detection" tag to the model card similar to the ones here: https://huggingface.co/models?pipeline_tag=zero-shot-object-detection&sort=trending. I opened a PR for that here: https://huggingface.co/omlab/OmDet-Turbo_tiny_SWIN_T/discussions/1

Would you be interested in this integration?

Kind regards,

Niels
ML Engineer @ HF 🤗 